### PR TITLE
Fix for error: props_children is not a function

### DIFF
--- a/packages/aws-amplify-react/src/Auth/Authenticator.jsx
+++ b/packages/aws-amplify-react/src/Auth/Authenticator.jsx
@@ -170,7 +170,7 @@ export default class Authenticator extends Component {
         ];
 
         const props_children_override =  React.Children.map(props_children, child => child.props.override);
-        hide = hide.filter((component) => !props_children.find(child => child.type === component));
+        hide = hide.filter((component) => !props_children_override.find(child => child.type === component));
         
         const render_props_children = React.Children.map(props_children, (child, index) => {
             return React.cloneElement(child, {


### PR DESCRIPTION
*Issue*
Breaking changes when using hideDefault={true}
*Description of changes:*
 Looking into the changelog there appears to be a typographical error


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
